### PR TITLE
feat: Add database backup/restore scripts and test improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build:
 e2e:
 	npm run test:ui
 
-e2e:ci
+e2e-ci:
 	npm run test:ci
 
 start:

--- a/Makefile
+++ b/Makefile
@@ -52,3 +52,13 @@ start-app: fetch-secrets
 
 stop-app: fetch-secrets
 	ENV=${ENV} DOCKER_USERNAME=${DOCKER_USERNAME} DOCKER_TAG=${DOCKER_TAG} docker-compose -p app --env-file .env -f deploy/docker-compose.app.yaml down
+
+download-db-backup:
+	mkdir -p ./tmp
+	rm -rf ./tmp/*
+	chmod +x ./scripts/download-db-backup.sh
+	./scripts/download-db-backup.sh ./tmp
+
+restore-db-backup:
+	chmod +x ./scripts/restore-db-from-backup.sh
+	./scripts/restore-db-from-backup.sh

--- a/scripts/download-db-backup.sh
+++ b/scripts/download-db-backup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+BACKUP_DIR=${1:-"./backup"}
+
+S3_BUCKET="anhquanlab-mongodb-backup"
+ENV="stg"
+
+# Fetch latest backup from S3 for stg environment
+latest_backup=$(aws s3api list-objects-v2 --bucket $S3_BUCKET --prefix $ENV/ --query 'Contents[?LastModified>=`2024-10-01`].[Key, LastModified]' --output text | sort -k2 -r | head -n 1)
+
+if [ -z "$latest_backup" ]; then
+  echo "No backups found for environment: $ENV"
+  exit 1
+fi
+
+env_prefix="$ENV/"
+backup_key=$(echo $latest_backup | awk '{print $1}' | sed "s|$env_prefix||")
+backup_date=$(echo $latest_backup | awk '{print $2}')
+
+echo "Downloading backup from $backup_date..... With key: $backup_key"
+
+backup_file="$BACKUP_DIR/$ENV-$backup_key.tar.gz"
+aws s3 cp "s3://$S3_BUCKET/$ENV/$backup_key" "$backup_file"
+
+tar xzf "$backup_file" -C "$BACKUP_DIR"

--- a/scripts/restore-db-from-backup.sh
+++ b/scripts/restore-db-from-backup.sh
@@ -1,0 +1,18 @@
+# BACKUP_FILE=
+
+DEFAULT_BACKUP_FOLDER=$(ls -1 -d ./tmp/*/ | head -n 1)
+
+BACKUP_FOLDER=${1:-"$DEFAULT_BACKUP_FOLDER"}
+MONGODB_URI=${2:-"mongodb://root:password123@localhost:27017"}
+DB_NAME="labadmin"
+
+echo "Restoring database from backup folder: $BACKUP_FOLDER to MongoDB URI: $MONGODB_URI"
+
+read -p "Please confirm the restore operation (y/n): " confirmation
+
+if [ "$confirmation" != "y" ]; then
+  echo "Restore operation cancelled."
+  exit 0
+fi
+
+mongorestore --uri=$MONGODB_URI --nsInclude $DB_NAME.* --drop $BACKUP_FOLDER

--- a/tests/helpers/combos.js
+++ b/tests/helpers/combos.js
@@ -19,7 +19,7 @@ async function goToCombos(page) {
  */
 async function createCombo(page, comboData) {
   await page.goto('/danh-muc-goi-xet-nghiem/new');
-  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
 
   // Fill combo name
   await page.getByRole('textbox', { name: 'Tên gói xét nghiệm' }).fill(comboData.name);

--- a/tests/specs/05-records.spec.js
+++ b/tests/specs/05-records.spec.js
@@ -107,7 +107,7 @@ test.describe('Record Management Flow', () => {
     const rowCount = await row.count();
     
     if (rowCount > 0) {
-      await row.locator('a:has-text("Chi tiết")').first().click();
+      await row.getByRole('link', { name: 'Xem' }).first().click();
       await page.waitForLoadState('networkidle');
       
       // Verify we're on the details page


### PR DESCRIPTION
## Summary

This PR adds database backup and restore functionality with test improvements:

### Changes Made

#### 1. **Database Backup/Restore Scripts**
- **`scripts/download-db-backup.sh`**: New script to download the latest MongoDB backup from S3
  - Fetches the latest backup from `anhquanlab-mongodb-backup` bucket for staging environment
  - Extracts backup tar.gz file to the specified directory
  
- **`scripts/restore-db-from-backup.sh`**: New script to restore MongoDB from local backup
  - Restores database from backup folder to MongoDB instance
  - Supports custom backup folder and MongoDB URI
  - Includes confirmation prompt before restoration
  - Targets the `labadmin` database

#### 2. **Makefile Updates**
- Fixed typo: `e2e:ci` → `e2e-ci:`
- Added two new targets:
  - `download-db-backup`: Downloads and extracts latest backup from S3
  - `restore-db-backup`: Restores database from local backup folder

#### 3. **Test Improvements**
- **`tests/helpers/combos.js`**: Changed wait strategy from `waitForLoadState('networkidle')` to `waitForTimeout(500)` for better test stability
- **`tests/specs/05-records.spec.js`**: Updated selector from CSS selector `a:has-text("Chi tiết")` to accessible `getByRole('link', { name: 'Xem' })` for better test reliability

### Benefits
- **Local Development**: Developers can now easily download and restore production-like data for local testing
- **Test Stability**: Improved test reliability with more robust wait strategies and accessible selectors
- **Build System**: Fixed Makefile syntax error

### Related Issues
N/A

### Testing
- Manual verification of script functionality
- E2E tests have been updated with improved selectors and wait strategies

### Checklist
- [x] Code follows project conventions
- [x] Tests updated/added
- [x] Scripts are executable and tested
- [x] Makefile syntax corrected