### PR TITLE
fix: Use timestamp in report filenames to prevent caching

### DIFF
--- a/internal/handlers/patient_handler.go
+++ b/internal/handlers/patient_handler.go
@@ -292,7 +292,7 @@ func (h *Handler) ComparePatientRecordsV1(w http.ResponseWriter, r *http.Request
 	}
 
 	fileName := fmt.Sprintf("%s-%s-tracking.xlsx",
-		time.Now().Format("20060102"),
+		time.Now().Format("20060102-150405"),
 		strings.ReplaceAll(records[0].Patient.Name, " ", "_"))
 
 	filePath, err := storer.Store(r.Context(), reader, fileName)

--- a/internal/handlers/record_handler.go
+++ b/internal/handlers/record_handler.go
@@ -158,7 +158,7 @@ func (h *Handler) ExportRecord(w http.ResponseWriter, r *http.Request) error {
 		BaseDir: "./reports",
 	}
 
-	fileName := fmt.Sprintf("%s-%s-%s.xlsx", time.Now().Format("20060102"), strings.ReplaceAll(record.Patient.Name, " ", "_"), req.ReportType)
+	fileName := fmt.Sprintf("%s-%s-%s.xlsx", time.Now().Format("20060102-150405"), strings.ReplaceAll(record.Patient.Name, " ", "_"), req.ReportType)
 	filePath, err := storer.Store(r.Context(), reader, fileName)
 	if err != nil {
 		return err

--- a/internal/handlers/tracking_handler.go
+++ b/internal/handlers/tracking_handler.go
@@ -135,7 +135,7 @@ func (h *Handler) CreateTrackingReport(w http.ResponseWriter, r *http.Request) e
 	}
 
 	fileName := fmt.Sprintf("%s-%s-tracking.xlsx",
-		time.Now().Format("20060102"),
+		time.Now().Format("20060102-150405"),
 		strings.ReplaceAll(records[0].Patient.Name, " ", "_"))
 
 	filePath, err := storer.Store(r.Context(), reader, fileName)


### PR DESCRIPTION
# fix: Use timestamp in report filenames to prevent caching

## Description

This PR fixes an issue where exported Excel reports were being cached by CloudFlare CDN due to identical filenames being generated for the same patient on the same day. The fix involves appending a timestamp (HHMMSS) to the filename to ensure uniqueness.

## Related Issue(s)

N/A

## Changes Made

- [x] Updated `internal/handlers/record_handler.go` to include timestamp in Result Report filenames.
- [x] Updated `internal/handlers/patient_handler.go` to include timestamp in Tracking Report filenames (Patient view).
- [x] Updated `internal/handlers/tracking_handler.go` to include timestamp in Tracking Report filenames (Tracking view).

## Review Checklist

- [x] Code follows project style guidelines.
- [ ] Tests have been added or updated to cover the changes.
- [ ] Documentation has been updated (if necessary).
- [ ] All automated checks pass.

## Additional Notes

The filename format changed from `YYYYMMDD-...` to `YYYYMMDD-HHMMSS-...`.