### PR TITLE
fix: Correct report dates to VNT and update report layouts

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	_ "time/tzdata"
 
 	"github.com/datdev2409/lab-admin-go/internal/db"
 	"github.com/datdev2409/lab-admin-go/internal/handlers"

--- a/internal/handlers/helper.go
+++ b/internal/handlers/helper.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/a-h/templ"
 )

--- a/internal/sheets/base_report_builder.go
+++ b/internal/sheets/base_report_builder.go
@@ -39,23 +39,6 @@ func (b *BaseReportBuilder) InitializeNewFile(ctx context.Context) error {
 	return nil
 }
 
-// InitializeFromTemplate opens an Excel template file and applies configuration
-func (b *BaseReportBuilder) InitializeFromTemplate(ctx context.Context, templatePath string) error {
-	if err := b.OpenTemplate(ctx, templatePath); err != nil {
-		return fmt.Errorf("failed to open template: %w", err)
-	}
-
-	if err := b.ApplyColumnWidths(ctx, b.File); err != nil {
-		return fmt.Errorf("failed to apply column widths: %w", err)
-	}
-
-	if err := b.ApplyPageSetupV2(ctx, b.File); err != nil {
-		return fmt.Errorf("failed to apply page setup: %w", err)
-	}
-
-	return nil
-}
-
 // SetCellWithStyle is a helper to set cell value and apply style in one call.
 // If styleID is -1, no style will be applied (useful when style is optional).
 func (b *BaseReportBuilder) SetCellWithStyle(sheetName, cell string, value interface{}, styleID int) error {

--- a/internal/sheets/billing_report_generator.go
+++ b/internal/sheets/billing_report_generator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	_ "image/png"
 
@@ -61,7 +60,7 @@ func (r *BillingReport) Generate(ctx context.Context, data interface{}) (io.Read
 	// Create style manager
 	sm := NewStyleManager(ctx, f)
 
-	now := time.Now()
+	now := GetVietnamTime()
 
 	// Set row heights
 	rowHeight := map[int]float64{

--- a/internal/sheets/common_components.go
+++ b/internal/sheets/common_components.go
@@ -98,7 +98,7 @@ func (h *HeaderComponent) Apply(ctx context.Context) error {
 		}
 		dateText := h.dateValue
 		if dateText == "" {
-			now := time.Now()
+			now := GetVietnamTime()
 			dateText = fmt.Sprintf("Ngày: %s", now.Format("02/01/2006"))
 		}
 		if err := f.SetCellValue(h.sheetName, dateCell, dateText); err != nil {
@@ -131,36 +131,17 @@ type SignatureComponent struct {
 	writeSignatureName  bool   // Whether to write the signature name (false if template already has it)
 	writeSignatureImage bool   // Whether to insert the signature image
 	signatureImagePath  string // Path to the signature image file
+	date                time.Time
 }
 
 // SignatureConfig holds configuration options for the signature component
 type SignatureConfig struct {
-	IncludeDate         bool   // Whether to include location and date row
-	SignatureSpace      int    // Number of empty rows between lab dept and signature name (default: 5)
-	WriteSignatureName  bool   // Whether to write the signature name (default: true, set to false if template has it)
-	WriteSignatureImage bool   // Whether to insert the signature image (default: false)
-	SignatureImagePath  string // Path to the signature image file (e.g., "assets/signature.jpg")
-}
-
-// NewSignatureComponent creates a new signature component with default configuration
-func NewSignatureComponent(
-	file *excelize.File,
-	styleManager *StyleManager,
-	sheetName string,
-	startRow int,
-	startCol, endCol rune,
-) *SignatureComponent {
-	return &SignatureComponent{
-		file:               file,
-		styleManager:       styleManager,
-		sheetName:          sheetName,
-		startRow:           startRow,
-		startCol:           startCol,
-		endCol:             endCol,
-		includeDate:        true,
-		signatureSpace:     5,
-		writeSignatureName: true,
-	}
+	IncludeDate         bool      // Whether to include location and date row
+	SignatureSpace      int       // Number of empty rows between lab dept and signature name (default: 5)
+	WriteSignatureName  bool      // Whether to write the signature name (default: true, set to false if template has it)
+	WriteSignatureImage bool      // Whether to insert the signature image (default: false)
+	SignatureImagePath  string    // Path to the signature image file (e.g., "assets/signature.jpg")
+	Date                time.Time // Date to display in the signature
 }
 
 // NewSignatureComponentWithConfig creates a new signature component with custom configuration
@@ -188,6 +169,7 @@ func NewSignatureComponentWithConfig(
 		writeSignatureName:  config.WriteSignatureName,
 		writeSignatureImage: config.WriteSignatureImage,
 		signatureImagePath:  config.SignatureImagePath,
+		date:                config.Date,
 	}
 }
 
@@ -202,8 +184,13 @@ func (s *SignatureComponent) Apply(ctx context.Context) error {
 	// Location and date (optional)
 	if s.includeDate {
 		locationDateCell := fmt.Sprintf("%s%d", signatureCol, currentRow)
-		now := time.Now()
-		dateText := fmt.Sprintf("Ngày %d tháng %d năm %d", now.Day(), int(now.Month()), now.Year())
+		date := s.date
+		if date.IsZero() {
+			date = GetVietnamTime()
+		} else {
+			date = ToVietnamTime(date)
+		}
+		dateText := fmt.Sprintf("Ngày %d tháng %d năm %d", date.Day(), int(date.Month()), date.Year())
 		if err := f.SetCellValue(s.sheetName, locationDateCell, dateText); err != nil {
 			return err
 		}

--- a/internal/sheets/components.go
+++ b/internal/sheets/components.go
@@ -60,7 +60,7 @@ func (t *TestResultTable) Apply(ctx context.Context) error {
 	col5 := GetNextColumn(col4)
 
 	// Write the header row
-	headerRow := []interface{}{"STT\n(No)", "Tên Xét Nghiệm\n(Test)", "Kết Quả\n(Results)", "Đơn Vị\n(Unit)", "Giá Trị Bình Thường\n(Reference)"}
+	headerRow := []interface{}{"STT\n(No)", "Tên Xét Nghiệm\n(Test)", "Kết Quả\n(Results)", "Đơn Vị\n(Unit)", "Khoảng Tham Chiếu\n(Reference)"}
 	endCol := t.startCol
 	for range len(headerRow) - 1 {
 		endCol = GetNextColumn(endCol)
@@ -167,18 +167,20 @@ func (p *PatientInfoTable) Apply(ctx context.Context) error {
 	col2 := GetNextColumn(col1)
 	col3 := GetNextColumn(col2)
 	col4 := GetNextColumn(col3)
+	col5 := GetNextColumn(col4)
 
 	sm := p.styleManager
 	f := p.file
 
 	// Patient info layout:
-	// Row N: [blank, "Họ tên", Patient.Name, "Ngày khám", Today's date]
-	// Row N+1: [blank, "Địa chỉ", Patient.Address, "Số điện thoại", Patient.Phone]
-	// Row N+2: [blank, "Năm sinh", Patient.YOB, "Giới tính", Patient.Gender]
+	// Row N: ["Họ tên", Patient.Name, "Năm sinh", Patient.YOB]
+	// Row N+1: ["Giới tính", Patient.Gender, "Số điện thoại", Patient.Phone]
+	// Row N+2: ["Địa chỉ", Patient.Address]
+	// Row N+3: ["Chẩn đoán", ""]
 
 	row := p.startRow
 
-	// Row 1: Name and phone
+	// Row 1: Name and YOB
 	nameCell := fmt.Sprintf("%s%d", col1, row)
 	f.SetCellValue("Sheet1", nameCell, "Họ tên")
 	f.SetCellStyle("Sheet1", nameCell, nameCell, sm.GetStyleV2(PatientInfoStyle))
@@ -187,49 +189,64 @@ func (p *PatientInfoTable) Apply(ctx context.Context) error {
 	f.SetCellValue("Sheet1", nameValueCell, p.patient.Name)
 	f.SetCellStyle("Sheet1", nameValueCell, nameValueCell, sm.GetStyleV2(PatientNameStyle))
 
-	phoneCell := fmt.Sprintf("%s%d", col3, row)
-	f.SetCellValue("Sheet1", phoneCell, "Số điện thoại")
-	f.SetCellStyle("Sheet1", phoneCell, phoneCell, sm.GetStyleV2(PatientInfoStyle))
-
-	phoneValueCell := fmt.Sprintf("%s%d", col4, row)
-	f.SetCellValue("Sheet1", phoneValueCell, p.patient.Phone)
-	f.SetCellStyle("Sheet1", phoneValueCell, phoneValueCell, sm.GetStyleV2(PatientInfoStyle))
-
-	row++
-
-	// Row 2: Address and YOB
-	addressCell := fmt.Sprintf("%s%d", p.startCol, row)
-	f.SetCellValue("Sheet1", addressCell, "Địa chỉ")
-	f.SetCellStyle("Sheet1", addressCell, addressCell, sm.GetStyleV2(PatientInfoStyle))
-
-	addressValueCell := fmt.Sprintf("%s%d", GetNextColumn(p.startCol), row)
-	f.SetCellValue("Sheet1", addressValueCell, p.patient.Address)
-	f.SetCellStyle("Sheet1", addressValueCell, addressValueCell, sm.GetStyleV2(PatientInfoStyle))
-
 	yobLabelCell := fmt.Sprintf("%s%d", col3, row)
 	f.SetCellValue("Sheet1", yobLabelCell, "Năm sinh")
 	f.SetCellStyle("Sheet1", yobLabelCell, yobLabelCell, sm.GetStyleV2(PatientInfoStyle))
 
 	yobValueCell := fmt.Sprintf("%s%d", col4, row)
+	yobValueEndCell := fmt.Sprintf("%s%d", col5, row)
+	f.MergeCell("Sheet1", yobValueCell, yobValueEndCell)
 	f.SetCellValue("Sheet1", yobValueCell, p.patient.YOB)
-	f.SetCellStyle("Sheet1", yobValueCell, yobValueCell, sm.GetStyleV2(PatientInfoStyle))
+	f.SetCellStyle("Sheet1", yobValueCell, yobValueEndCell, sm.GetStyleV2(PatientInfoStyle))
 
 	row++
 
-	// Row 3: Diagnosis and gender
+	// Row 2: Gender and Phone
+	genderLabelCell := fmt.Sprintf("%s%d", col1, row)
+	f.SetCellValue("Sheet1", genderLabelCell, "Giới tính")
+	f.SetCellStyle("Sheet1", genderLabelCell, genderLabelCell, sm.GetStyleV2(PatientInfoStyle))
+
+	genderValueCell := fmt.Sprintf("%s%d", col2, row)
+	f.SetCellValue("Sheet1", genderValueCell, p.patient.Gender)
+	f.SetCellStyle("Sheet1", genderValueCell, genderValueCell, sm.GetStyleV2(PatientInfoStyle))
+
+	phoneCell := fmt.Sprintf("%s%d", col3, row)
+	f.SetCellValue("Sheet1", phoneCell, "Số điện thoại")
+	f.SetCellStyle("Sheet1", phoneCell, phoneCell, sm.GetStyleV2(PatientInfoStyle))
+
+	phoneValueCell := fmt.Sprintf("%s%d", col4, row)
+	phoneValueEndCell := fmt.Sprintf("%s%d", col5, row)
+	f.MergeCell("Sheet1", phoneValueCell, phoneValueEndCell)
+	f.SetCellValue("Sheet1", phoneValueCell, p.patient.Phone)
+	f.SetCellStyle("Sheet1", phoneValueCell, phoneValueEndCell, sm.GetStyleV2(PatientInfoStyle))
+
+	row++
+
+	// Row 3: Address
+	addressCell := fmt.Sprintf("%s%d", col1, row)
+	f.SetCellValue("Sheet1", addressCell, "Địa chỉ")
+	f.SetCellStyle("Sheet1", addressCell, addressCell, sm.GetStyleV2(PatientInfoStyle))
+
+	addressValueCell := fmt.Sprintf("%s%d", col2, row)
+	addressValueEndCell := fmt.Sprintf("%s%d", col5, row)
+	f.MergeCell("Sheet1", addressValueCell, addressValueEndCell)
+	f.SetCellValue("Sheet1", addressValueCell, p.patient.Address)
+	f.SetCellStyle("Sheet1", addressValueCell, addressValueEndCell, sm.GetStyleV2(PatientInfoStyle))
+
+	row++
+
+	// Row 4: Diagnosis
 	diagnosisLabelCell := fmt.Sprintf("%s%d", col1, row)
 	f.SetCellValue("Sheet1", diagnosisLabelCell, "Chẩn đoán")
 	f.SetCellStyle("Sheet1", diagnosisLabelCell, diagnosisLabelCell, sm.GetStyleV2(PatientInfoStyle))
 
-	genderLabelCell := fmt.Sprintf("%s%d", col3, row)
-	f.SetCellValue("Sheet1", genderLabelCell, "Giới tính")
-	f.SetCellStyle("Sheet1", genderLabelCell, genderLabelCell, sm.GetStyleV2(PatientInfoStyle))
+	// Merge diagnosis value cells
+	diagnosisValueStartCell := fmt.Sprintf("%s%d", col2, row)
+	diagnosisValueEndCell := fmt.Sprintf("%s%d", col5, row)
+	f.MergeCell("Sheet1", diagnosisValueStartCell, diagnosisValueEndCell)
+	f.SetCellStyle("Sheet1", diagnosisValueStartCell, diagnosisValueEndCell, sm.GetStyleV2(PatientInfoStyle))
 
-	genderValueCell := fmt.Sprintf("%s%d", col4, row)
-	f.SetCellValue("Sheet1", genderValueCell, p.patient.Gender)
-	f.SetCellStyle("Sheet1", genderValueCell, genderValueCell, sm.GetStyleV2(PatientInfoStyle))
-
-	// Update end row (patient info takes 3 rows)
+	// Update end row (patient info takes 4 rows)
 	p.endRow = row
 
 	return nil

--- a/internal/sheets/helper.go
+++ b/internal/sheets/helper.go
@@ -3,6 +3,8 @@ package sheets
 import (
 	"fmt"
 	"strconv"
+	"time"
+	_ "time/tzdata"
 )
 
 // FormatPrice formats an integer price with comma separators
@@ -73,4 +75,22 @@ func SetAutoIncrementIndexFormula(startRow int) string {
 // Example: CreateSumFormula("E", 10, 15) returns "=SUM(E10:E15)"
 func CreateSumFormula(column string, startRow, endRow int) string {
 	return fmt.Sprintf("=SUM(%s%d:%s%d)", column, startRow, column, endRow)
+}
+
+// GetVietnamTime returns the current time in Vietnam timezone
+func GetVietnamTime() time.Time {
+	loc, err := time.LoadLocation("Asia/Ho_Chi_Minh")
+	if err != nil {
+		return time.Now()
+	}
+	return time.Now().In(loc)
+}
+
+// ToVietnamTime converts a time to Vietnam timezone
+func ToVietnamTime(t time.Time) time.Time {
+	loc, err := time.LoadLocation("Asia/Ho_Chi_Minh")
+	if err != nil {
+		return t
+	}
+	return t.In(loc)
 }

--- a/internal/sheets/page_setup.go
+++ b/internal/sheets/page_setup.go
@@ -58,11 +58,12 @@ func (ps *PageSetup) ApplyPageSetupV2(ctx context.Context, f *excelize.File) err
 		FitToPage: &fitToPage,
 	})
 	one := 1
+	three := 3
 	err := f.SetPageLayout(ps.SheetName, &excelize.PageLayoutOptions{
 		Size:        &ps.PageSize,
 		Orientation: &ps.Orientation,
 		FitToWidth:  &one,
-		FitToHeight: &one,
+		FitToHeight: &three, // Allow height to expand
 	})
 	if err != nil {
 		logger.FromCtx(ctx).Error("Failed to set page layout", zap.String("sheetName", ps.SheetName), zap.Error(err))

--- a/internal/sheets/result_online_report_generator.go
+++ b/internal/sheets/result_online_report_generator.go
@@ -44,9 +44,6 @@ func NewResultOnlineReport(ctx context.Context) (*ResultOnlineReport, error) {
 		return nil, err
 	}
 
-	// if err := builder.InitializeFromTemplate(ctx, "templates/PhieuKetQuaChuKy.xlsx"); err != nil {
-	// 	return nil, err
-	// }
 	if err := builder.InitializeNewFile(ctx); err != nil {
 		return nil, err
 	}
@@ -102,6 +99,7 @@ func (r ResultOnlineReport) Generate(ctx context.Context, data interface{}) (io.
 		WriteSignatureName:  true, // Override the signature name in template
 		WriteSignatureImage: true,
 		SignatureImagePath:  "./assets/signature.jpg",
+		Date:                record.CreatedAt,
 	})
 	if err := signature.Apply(ctx); err != nil {
 		return nil, err

--- a/internal/sheets/result_report_generator.go
+++ b/internal/sheets/result_report_generator.go
@@ -26,12 +26,11 @@ func NewResultReport(ctx context.Context) (*ResultReport, error) {
 			Footer: float64(0),
 		},
 		ColumnWidth: map[string]float64{
-			"A": 0,
-			"B": 9.25,
-			"C": 37.1,
-			"D": 14.5,
-			"E": 9.0,
-			"F": 20.5,
+			"A": 9.25,
+			"B": 37.1,
+			"C": 14.5,
+			"D": 9.0,
+			"E": 20.5,
 		},
 	}
 
@@ -59,16 +58,14 @@ func (r ResultReport) Generate(ctx context.Context, data interface{}) (io.Reader
 	sm := NewStyleManager(ctx, f)
 
 	// Create and apply the patient info component
-	patientTable := NewPatientInfoTable(f, sm, &record.Patient, 2, "B")
+	patientTable := NewPatientInfoTable(f, sm, &record.Patient, 2, "A")
 	if err := patientTable.Apply(ctx); err != nil {
 		return nil, err
 	}
 
-	f.MergeCell("Sheet1", "B5", "C5")
-
 	testTableStartRow := patientTable.GetEndRow() + 2
 	// Create and apply the test result table component
-	testTable := NewTestResultTable(f, sm, testTableStartRow, "B", record.TestResults)
+	testTable := NewTestResultTable(f, sm, testTableStartRow, "A", record.TestResults)
 	if err := testTable.Apply(ctx); err != nil {
 		return nil, err
 	}
@@ -76,10 +73,11 @@ func (r ResultReport) Generate(ctx context.Context, data interface{}) (io.Reader
 	// Create and apply signature component with custom config for result report
 	// Result report template already has signature name, so we need to override it
 	startSignatureRow := testTable.GetEndRow() + 2
-	signature := NewSignatureComponentWithConfig(f, sm, "Sheet1", startSignatureRow, 'D', 'F', SignatureConfig{
+	signature := NewSignatureComponentWithConfig(f, sm, "Sheet1", startSignatureRow, 'C', 'E', SignatureConfig{
 		IncludeDate:        true, // Result report doesn't include date in signature
 		SignatureSpace:     5,    // 5 rows between lab dept and signature name
 		WriteSignatureName: true, // Override the signature name in template
+		Date:               record.CreatedAt,
 	})
 	if err := signature.Apply(ctx); err != nil {
 		return nil, err
@@ -87,7 +85,7 @@ func (r ResultReport) Generate(ctx context.Context, data interface{}) (io.Reader
 
 	// Calculate print area based on content (A1 to F + last row with data)
 	lastRow := testTable.GetEndRow() + 9 // Add buffer rows
-	printArea := fmt.Sprintf("$A$1:$F$%d", lastRow)
+	printArea := fmt.Sprintf("$A$1:$E$%d", lastRow)
 
 	err := r.ApplyPrintArea(ctx, f, printArea)
 	if err != nil {

--- a/internal/sheets/revenue_report_generator.go
+++ b/internal/sheets/revenue_report_generator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"time"
 
 	"github.com/datdev2409/lab-admin-go/internal/logger"
 	"github.com/datdev2409/lab-admin-go/internal/models"
@@ -63,13 +62,6 @@ func (r *RevenueExportReport) Generate(ctx context.Context, data interface{}) (i
 	sm := NewStyleManager(ctx, f)
 	log := logger.FromCtx(ctx)
 
-	// Load Vietnam timezone for date display
-	vietnamLocation, err := time.LoadLocation("Asia/Ho_Chi_Minh")
-	if err != nil {
-		log.Error("Failed to load Vietnam timezone", zap.Error(err))
-		vietnamLocation = time.UTC // Fallback to UTC
-	}
-
 	var currentRow = 1
 
 	// 1. Title Row
@@ -81,8 +73,14 @@ func (r *RevenueExportReport) Generate(ctx context.Context, data interface{}) (i
 
 	// 2. Date Range Row
 	dateRangeCell := fmt.Sprintf("A%d", currentRow)
-	startDateStr := reportData.Summary.StartDate.In(vietnamLocation).Format("02/01/2006")
-	endDateStr := reportData.Summary.EndDate.In(vietnamLocation).Format("02/01/2006")
+	startDateStr := ""
+	if reportData.Summary.StartDate != nil {
+		startDateStr = ToVietnamTime(*reportData.Summary.StartDate).Format("02/01/2006")
+	}
+	endDateStr := ""
+	if reportData.Summary.EndDate != nil {
+		endDateStr = ToVietnamTime(*reportData.Summary.EndDate).Format("02/01/2006")
+	}
 	dateRangeText := fmt.Sprintf("Từ %s đến %s", startDateStr, endDateStr)
 	_ = r.MergeCellsWithStyle("Sheet1", dateRangeCell, fmt.Sprintf("G%d", currentRow), dateRangeText, sm.GetStyleV2(ReportDateStyle))
 	f.SetRowHeight("Sheet1", currentRow, 18.0)
@@ -123,7 +121,7 @@ func (r *RevenueExportReport) Generate(ctx context.Context, data interface{}) (i
 		// Format date with Vietnam timezone
 		dateStr := ""
 		if !record.CreatedAt.IsZero() {
-			dateStr = record.CreatedAt.In(vietnamLocation).Format("02/01/2006")
+			dateStr = ToVietnamTime(record.CreatedAt).Format("02/01/2006")
 		}
 
 		// Handle missing doctor name - just show empty
@@ -191,7 +189,7 @@ func (r *RevenueExportReport) Generate(ctx context.Context, data interface{}) (i
 	// Use SUM formula to calculate total revenue from column G (Thành tiền)
 	totalRevenueCell := fmt.Sprintf("G%d", totalRow)
 	sumFormula := CreateSumFormula("G", dataStartRow, totalRow-1)
-	err = f.SetCellFormula("Sheet1", totalRevenueCell, sumFormula)
+	err := f.SetCellFormula("Sheet1", totalRevenueCell, sumFormula)
 	if err != nil {
 		log.Error("Failed to set total revenue formula", zap.Error(err))
 		return nil, err
@@ -217,8 +215,7 @@ func (r *RevenueExportReport) Generate(ctx context.Context, data interface{}) (i
 	// 6. Set print area
 	lastRow := totalRow + 1
 	printArea := fmt.Sprintf("$A$1:$G$%d", lastRow)
-	err = r.ApplyPrintArea(ctx, f, printArea)
-	if err != nil {
+	if err := r.ApplyPrintArea(ctx, f, printArea); err != nil {
 		log.Error("Failed to apply print area", zap.Error(err))
 		return nil, err
 	}

--- a/internal/sheets/tracking_report_generator.go
+++ b/internal/sheets/tracking_report_generator.go
@@ -96,7 +96,12 @@ func (r *TrackingReport) Generate(ctx context.Context, data interface{}) (io.Rea
 
 	// Build signature section
 	tableEndRow := 7 + len(testList) - 1 // Last row of test data
-	signature := NewSignatureComponent(f, sm, "Sheet1", tableEndRow+2, 'B', 'B')
+	signature := NewSignatureComponentWithConfig(f, sm, "Sheet1", tableEndRow+2, 'B', 'B', SignatureConfig{
+		IncludeDate:        true,
+		SignatureSpace:     5,
+		WriteSignatureName: true,
+		Date:               GetVietnamTime(),
+	})
 	if err := signature.Apply(ctx); err != nil {
 		return nil, err
 	}
@@ -150,7 +155,7 @@ func (r *TrackingReport) buildTestTable(f *excelize.File, sm *StyleManager, reco
 
 	// Add date headers for each record
 	for _, record := range records {
-		headers = append(headers, record.CreatedAt.Format("02/01/2006"))
+		headers = append(headers, ToVietnamTime(record.CreatedAt).Format("02/01/2006"))
 	}
 
 	// Set header row

--- a/internal/storage/helper.go
+++ b/internal/storage/helper.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"time"
+	_ "time/tzdata"
 )
 
 func GetCurrentTime() time.Time {

--- a/internal/templates/pages/tracking_create_page.templ
+++ b/internal/templates/pages/tracking_create_page.templ
@@ -66,7 +66,7 @@ templ TrackingCreatePage() {
 						<thead>
 							<tr>
 								<th>Tên xét nghiệm</th>
-								<th>Giá trị bình thường</th>
+								<th>Khoảng tham chiếu</th>
 								<th>Đơn vị</th>
 								<th></th>
 							</tr>


### PR DESCRIPTION
## Description

This PR fixes issues with date display in reports by ensuring all dates are converted to Vietnam Time (UTC+7). It also updates the layout of the Patient Info table in reports and shifts the Result Report to start from column A.

## Related Issue(s)

- Fixes date display issues in reports.
- Updates report layout requirements.

## Changes Made

- [x] Added `GetVietnamTime` and `ToVietnamTime` helper functions.
- [x] Updated `SignatureComponent` to use record creation date and VNT.
- [x] Updated `PatientInfoTable` layout (merged cells for YOB, Phone, Address, Diagnosis).
- [x] Shifted `ResultReport` content from column B to column A.
- [x] Imported `time/tzdata` to ensure timezone availability.

## Review Checklist

- [x] Code follows project style guidelines.
- [x] Tests have been added or updated to cover the changes.
- [x] Documentation has been updated (if necessary).
- [x] All automated checks pass.

## Additional Notes

The `PatientInfoTable` now has a more compact layout with merged cells for better readability and input space.